### PR TITLE
Fixing dialog for non attackable big buildings (#3684)

### DIFF
--- a/src/wui/attack_box.cc
+++ b/src/wui/attack_box.cc
@@ -47,7 +47,6 @@ AttackBox::AttackBox(UI::Panel* parent,
 
 std::vector<Widelands::Soldier*> AttackBox::get_max_attackers() {
 	assert(player_);
-
 	if (upcast(Building, building, map_.get_immovable(*node_coordinates_))) {
 		if (player_->vision(map_.get_index(building->get_position(), map_.get_width())) > 1) {
 			std::vector<Widelands::Soldier*> v;
@@ -262,6 +261,8 @@ void AttackBox::init() {
 
 	soldiers_slider_->set_enabled(max_attackers > 0);
 	more_soldiers_->set_enabled(max_attackers > 0);
+	// Update the list of soldiers now to avoid a flickering window in the next tick
+	update_attack(false);
 }
 
 void AttackBox::send_less_soldiers() {

--- a/src/wui/fieldaction.cc
+++ b/src/wui/fieldaction.cc
@@ -395,10 +395,14 @@ void FieldActionWindow::add_buttons_auto() {
 				add_button(buildbox, "destroy_waterway", pic_remwaterway,
 				           &FieldActionWindow::act_removewaterway, _("Destroy a waterway"));
 		}
-	} else if (player_ &&
-	           1 < player_->vision(
-	                  Widelands::Map::get_index(node_, ibase().egbase().map().get_width())))
-		add_buttons_attack();
+	} else if (player_) {
+		if (upcast(Building, building, map_.get_immovable(node_))) {
+			if (1 < player_->vision(Widelands::Map::get_index(
+			           building->get_position(), ibase().egbase().map().get_width()))) {
+				add_buttons_attack();
+			}
+		}
+	}
 
 	//  Watch actions, only when in game (no use in editor).
 	if (dynamic_cast<const Game*>(&ibase().egbase())) {


### PR DESCRIPTION
* Fixing bug that an attack window can be opened for a not attackable big building.
* Fixing sporadic flickering of newly opened attack window.